### PR TITLE
find -> walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "on demand" record creation
    - e.g. `ls | take 1` does only 1 read access to the file system
    - significative but acceptable performance penalty
+- `find` has been renamed to `walk`
+  - added `size` key, enabling to quickly find the largest file by doing `walk . | sort size`
 
 ### Fixed
 - storing history in `$HOME/.hosh_history` instead of `$HOME/.hosh.history)

--- a/src/main/java/hosh/modules/FileSystemModule.java
+++ b/src/main/java/hosh/modules/FileSystemModule.java
@@ -268,7 +268,11 @@ public class FileSystemModule implements Module {
 			try {
 				Path target = followSymlinksRecursively(resolveAsAbsolutePath(state.getCwd(), Path.of(args.get(0))));
 				if (!Files.exists(target)) {
-					err.send(Records.singleton(Keys.ERROR, Values.ofText("path does not exist: " + target)));
+					err.send(Records.singleton(Keys.ERROR, Values.ofText("not found")));
+					return ExitStatus.error();
+				}
+				if (!Files.isDirectory(target)) {
+					err.send(Records.singleton(Keys.ERROR, Values.ofText("not a directory")));
 					return ExitStatus.error();
 				}
 				Files.walkFileTree(target, new VisitCallback(out));
@@ -290,11 +294,6 @@ public class FileSystemModule implements Module {
 
 			@Override
 			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-				out.send(Records
-					         .builder()
-					         .entry(Keys.PATH, Values.ofPath(dir))
-					         .entry(Keys.SIZE, Values.none())
-					         .build());
 				return FileVisitResult.CONTINUE;
 			}
 

--- a/src/main/java/hosh/modules/FileSystemModule.java
+++ b/src/main/java/hosh/modules/FileSystemModule.java
@@ -344,9 +344,14 @@ public class FileSystemModule implements Module {
 			String pattern = args.get(0);
 			PathMatcher pathMatcher = state.getCwd().getFileSystem().getPathMatcher("glob:" + pattern);
 			for (Record record : InputChannel.iterate(in)) {
-				record.value(Keys.PATH).flatMap(v -> v.unwrap(Path.class)).filter(pathMatcher::matches).ifPresent(p -> {
-					out.send(record);
-				});
+				record.value(Keys.PATH)
+					.flatMap(v -> v.unwrap(Path.class))
+					.map(Path::getFileName)
+					.filter(pathMatcher::matches)
+					.ifPresent(p -> {
+						out.send(record);
+					}
+				);
 			}
 			return ExitStatus.success();
 		}

--- a/src/main/java/hosh/modules/FileSystemModule.java
+++ b/src/main/java/hosh/modules/FileSystemModule.java
@@ -54,9 +54,10 @@ import java.nio.file.AccessDeniedException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
@@ -262,18 +263,58 @@ public class FileSystemModule implements Module {
 				err.send(Records.singleton(Keys.ERROR, Values.ofText("expecting one argument")));
 				return ExitStatus.error();
 			}
-			Path target = resolveAsAbsolutePath(state.getCwd(), Path.of(args.get(0)));
-			try (Stream<Path> stream = Files.walk(followSymlinksRecursively(target))) {
-				stream.forEach(path -> {
-					Record result = Records.singleton(Keys.PATH, Values.ofPath(path.toAbsolutePath()));
-					out.send(result);
-				});
+			try {
+				Path target = followSymlinksRecursively(resolveAsAbsolutePath(state.getCwd(), Path.of(args.get(0))));
+				if (!Files.exists(target)) {
+					err.send(Records.singleton(Keys.ERROR, Values.ofText("path does not exist: " + target)));
+					return ExitStatus.error();
+				}
+				Files.walkFileTree(target, new VisitCallback(out));
 				return ExitStatus.success();
-			} catch (NoSuchFileException e) {
-				err.send(Records.singleton(Keys.ERROR, Values.ofText("path does not exist: " + e.getFile())));
-				return ExitStatus.error();
 			} catch (IOException e) {
 				throw new UncheckedIOException(e);
+			}
+		}
+
+		private static class VisitCallback implements FileVisitor<Path> {
+
+			private static final Logger LOGGER = LoggerFactory.forEnclosingClass();
+
+			private final OutputChannel out;
+
+			public VisitCallback(OutputChannel out) {
+				this.out = out;
+			}
+
+			@Override
+			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+				out.send(Records
+					         .builder()
+					         .entry(Keys.PATH, Values.ofPath(dir))
+					         .entry(Keys.SIZE, Values.none())
+					         .build());
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+				out.send(Records
+					         .builder()
+					         .entry(Keys.PATH, Values.ofPath(file))
+					         .entry(Keys.SIZE, Values.ofSize(attrs.size()))
+					         .build());
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult visitFileFailed(Path file, IOException exc) {
+				LOGGER.log(Level.SEVERE, "error while visiting: " + file, exc);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+				return FileVisitResult.CONTINUE;
 			}
 		}
 	}

--- a/src/main/java/hosh/modules/FileSystemModule.java
+++ b/src/main/java/hosh/modules/FileSystemModule.java
@@ -77,7 +77,7 @@ public class FileSystemModule implements Module {
 		registry.registerCommand("cwd", CurrentWorkingDirectory::new);
 		registry.registerCommand("cd", ChangeDirectory::new);
 		registry.registerCommand("lines", Lines::new);
-		registry.registerCommand("find", Find::new);
+		registry.registerCommand("walk", Walk::new);
 		registry.registerCommand("cp", Copy::new);
 		registry.registerCommand("mv", Move::new);
 		registry.registerCommand("rm", Remove::new);
@@ -244,10 +244,10 @@ public class FileSystemModule implements Module {
 
 	@Description("walk directory recursively")
 	@Examples({
-		@Example(command = "find .", description = "recursively output all paths in '.'"),
-		@Example(command = "find /tmp", description = "recursively output all paths in '/tmp'"),
+		@Example(command = "walk .", description = "recursively output all paths in '.'"),
+		@Example(command = "walk /tmp", description = "recursively output all paths in '/tmp'"),
 	})
-	public static class Find implements Command, StateAware {
+	public static class Walk implements Command, StateAware {
 
 		private State state;
 

--- a/src/main/java/hosh/spi/Values.java
+++ b/src/main/java/hosh/spi/Values.java
@@ -463,6 +463,14 @@ public class Values {
 			return Objects.hash(path);
 		}
 
+		@Override
+		public <T> Optional<T> unwrap(Class<T> type) {
+			if (type.equals(Path.class)) {
+				return Optional.of(type.cast(path));
+			}
+			return Optional.empty();
+		}
+
 		private static final Comparator<Path> PATH_COMPARATOR = Comparator
 			                                                        .comparing(Path::toString, new AlphaNumericStringComparator());
 

--- a/src/test/java/hosh/modules/FileSystemModuleTest.java
+++ b/src/test/java/hosh/modules/FileSystemModuleTest.java
@@ -811,7 +811,7 @@ public class FileSystemModuleTest {
 
 	@Nested
 	@ExtendWith(MockitoExtension.class)
-	public class GlobTest {
+	public class ProbeTest {
 
 		@RegisterExtension
 		public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -855,7 +855,7 @@ public class FileSystemModuleTest {
 
 	@Nested
 	@ExtendWith(MockitoExtension.class)
-	public class ProbeTest {
+	public class GlobTest {
 
 		@RegisterExtension
 		public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -886,9 +886,22 @@ public class FileSystemModuleTest {
 
 		@SuppressWarnings("unchecked")
 		@Test
-		public void match() {
+		public void matchRelativePath() {
 			given(state.getCwd()).willReturn(temporaryFolder.toPath());
 			Record record = Records.singleton(Keys.PATH, Values.ofPath(Path.of("file.java")));
+			given(in.recv()).willReturn(Optional.of(record), Optional.empty());
+			ExitStatus exitStatus = sut.run(List.of("*.java"), in, out, err);
+			assertThat(exitStatus).isSuccess();
+			then(in).should(times(2)).recv();
+			then(out).should().send(record);
+			then(err).shouldHaveNoInteractions();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		public void matchAbsolutePath() {
+			given(state.getCwd()).willReturn(temporaryFolder.toPath());
+			Record record = Records.singleton(Keys.PATH, Values.ofPath(Path.of("/tmp/file.java")));
 			given(in.recv()).willReturn(Optional.of(record), Optional.empty());
 			ExitStatus exitStatus = sut.run(List.of("*.java"), in, out, err);
 			assertThat(exitStatus).isSuccess();

--- a/src/test/java/hosh/modules/FileSystemModuleTest.java
+++ b/src/test/java/hosh/modules/FileSystemModuleTest.java
@@ -27,7 +27,7 @@ import hosh.doc.Bug;
 import hosh.modules.FileSystemModule.ChangeDirectory;
 import hosh.modules.FileSystemModule.Copy;
 import hosh.modules.FileSystemModule.CurrentWorkingDirectory;
-import hosh.modules.FileSystemModule.Find;
+import hosh.modules.FileSystemModule.Walk;
 import hosh.modules.FileSystemModule.Hardlink;
 import hosh.modules.FileSystemModule.Lines;
 import hosh.modules.FileSystemModule.ListFiles;
@@ -715,7 +715,7 @@ public class FileSystemModuleTest {
 
 	@Nested
 	@ExtendWith(MockitoExtension.class)
-	public class FindTest {
+	public class WalkTest {
 
 		@RegisterExtension
 		public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -733,7 +733,7 @@ public class FileSystemModuleTest {
 		private OutputChannel err;
 
 		@InjectMocks
-		private Find sut;
+		private Walk sut;
 
 		@Test
 		public void noArgs() {

--- a/src/test/java/hosh/modules/FileSystemModuleTest.java
+++ b/src/test/java/hosh/modules/FileSystemModuleTest.java
@@ -750,7 +750,7 @@ public class FileSystemModuleTest {
 			File newFile = temporaryFolder.newFile("file.txt");
 			ExitStatus exitStatus = sut.run(List.of("."), in, out, err);
 			assertThat(exitStatus).isSuccess();
-			then(out).should().send(Records.singleton(Keys.PATH, Values.ofPath(newFile.toPath().toAbsolutePath())));
+			then(out).should().send(RecordMatcher.of(Keys.PATH, Values.ofPath(newFile.toPath().toAbsolutePath()), Keys.SIZE, Values.ofSize(0)));
 			then(err).shouldHaveNoInteractions();
 			then(in).shouldHaveNoInteractions();
 		}
@@ -772,7 +772,7 @@ public class FileSystemModuleTest {
 			File newFile = temporaryFolder.newFile("file.txt");
 			ExitStatus exitStatus = sut.run(List.of(temporaryFolder.toPath().toAbsolutePath().toString()), in, out, err);
 			assertThat(exitStatus).isSuccess();
-			then(out).should().send(Records.singleton(Keys.PATH, Values.ofPath(newFile.toPath().toAbsolutePath())));
+			then(out).should().send(RecordMatcher.of(Keys.PATH, Values.ofPath(newFile.toPath().toAbsolutePath()), Keys.SIZE, Values.ofSize(0)));
 			then(err).shouldHaveNoInteractions();
 			then(in).shouldHaveNoInteractions();
 		}

--- a/src/test/java/hosh/testsupport/TemporaryFolder.java
+++ b/src/test/java/hosh/testsupport/TemporaryFolder.java
@@ -23,6 +23,7 @@
  */
 package hosh.testsupport;
 
+import hosh.doc.Todo;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.Extension;


### PR DESCRIPTION
- renamed `find` to `walk`
- only directories as input
- only files in output 
- adding size key to the output record in order to be able to sort by size
