### PR TITLE
porting to java modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - switched back to jansi: final jar now is 1.3MB instead of 2.5MB
 - azure-pipelines -> github-actions
 - enabling parallel test execution
+- preliminary introduction of java-module.info
 
 ### Fixed
 - #212: now it is possible to use several external commands in a pipeline

--- a/pom.xml
+++ b/pom.xml
@@ -146,14 +146,16 @@
 				<version>3.8.1</version>
 				<configuration>
 					<source>11</source>
-					<release>11</release>
+					<target>11</target>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>
 					<useIncrementalCompilation>false</useIncrementalCompilation>
 					<staleMillis>1</staleMillis>
 					<compilerArgs>
+						<arg>--add-exports</arg><arg>java.base/jdk.internal.misc=hosh</arg>
 						<arg>-Werror</arg>
 						<arg>-Xlint:all</arg>
+						<arg>-Xlint:-requires-automatic</arg>
 						<arg>-Xpkginfo:always</arg>
 					</compilerArgs>
 				</configuration>
@@ -224,9 +226,7 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<archive>
-						<manifest>
-							<mainClass>hosh.Hosh</mainClass>
-						</manifest>
+						<manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
 					<attach>false</attach>
 					<appendAssemblyId>false</appendAssemblyId>
@@ -249,6 +249,7 @@
 				<configuration>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<trimStackTrace>false</trimStackTrace>
+					<argLine>--add-exports java.base/jdk.internal.misc=hosh</argLine>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -345,6 +346,7 @@
 							<sourceDirectories>
 								<sourceDirectory>src/main/java</sourceDirectory>
 							</sourceDirectories>
+							<excludes>**/module-info.java</excludes>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018-2020 Davide Angelocola
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+module hosh {
+	requires java.base;
+	requires java.logging;
+	requires java.net.http;
+
+	requires jline.reader;
+	requires jline.terminal;
+
+	requires commons.cli;
+
+	requires org.antlr.antlr4.runtime;
+
+	// workaround for signal handling
+	requires jdk.unsupported;
+
+	// workarounds for mockito
+	opens hosh;
+	opens hosh.runtime;
+	opens hosh.spi;
+	opens hosh.modules;
+}

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Main-Class: hosh.Hosh
+Add-Exports: java.base/jdk.internal.misc
+


### PR DESCRIPTION
experimental migration to java modules

by now all modules are flattened into `hosh`, let's try later to:
- have one module per package with same structure as described in `ArchitectureFitnessTest`
- reflection is almost zero (missing few calls in `help` and jline3)