### PR TITLE
Feature/glob alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- lambda command
+  - alternative to glob expansion
+  - `command | { size -> ... ` binding of `size` variable for each incoming record
 - using alphanum for generic text too
 - new `sort` features:
    - `sort asc key`
@@ -20,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preliminary introduction of java-module.info
 
 ### Fixed
-- #212: now it is possible to use several external commands in a pipeline
+- #212: now it is possible to use several external commands at once in a pipeline
 
 ## [0.0.36] - 2020-01-30
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@
 
 ## Examples
 
+## Glob expansion
+
+To recursively remove all `.class` files in `target`:
+ 
+`walk target | glob '*.class' | { path -> rm ${path}; echo removed ${path} }`
+
 ### Sorting
 
 Sorting is always performed using a well defined key column:

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
 						<arg>-Xlint:all</arg>
 						<arg>-Xlint:-requires-automatic</arg>
 						<arg>-Xpkginfo:always</arg>
-						<arg>--add-exports</arg><arg>java.base/jdk.internal.misc=hosh</arg>
+						<arg>--add-exports</arg><arg>java.base/jdk.internal.misc=ALL-UNNAMED</arg>
 					</compilerArgs>
 				</configuration>
 			</plugin>
@@ -249,7 +249,7 @@
 				<configuration>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<trimStackTrace>false</trimStackTrace>
-					<argLine>--add-exports java.base/jdk.internal.misc=hosh</argLine>
+					<argLine>--add-exports java.base/jdk.internal.misc=ALL-UNNAMED</argLine>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,10 @@
 					<useIncrementalCompilation>false</useIncrementalCompilation>
 					<staleMillis>1</staleMillis>
 					<compilerArgs>
-						<arg>-Werror</arg>
 						<arg>-Xlint:all</arg>
 						<arg>-Xlint:-requires-automatic</arg>
 						<arg>-Xpkginfo:always</arg>
-						<arg>--add-exports</arg><arg>java.base/jdk.internal.misc=ALL-UNNAMED</arg>
+						<arg>--add-exports</arg><arg>java.base/jdk.internal.misc=hosh</arg>
 					</compilerArgs>
 				</configuration>
 			</plugin>
@@ -249,7 +248,7 @@
 				<configuration>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<trimStackTrace>false</trimStackTrace>
-					<argLine>--add-exports java.base/jdk.internal.misc=ALL-UNNAMED</argLine>
+					<argLine>--add-exports java.base/jdk.internal.misc=hosh</argLine>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,11 @@
 					<useIncrementalCompilation>false</useIncrementalCompilation>
 					<staleMillis>1</staleMillis>
 					<compilerArgs>
-						<arg>--add-exports</arg><arg>java.base/jdk.internal.misc=hosh</arg>
 						<arg>-Werror</arg>
 						<arg>-Xlint:all</arg>
 						<arg>-Xlint:-requires-automatic</arg>
 						<arg>-Xpkginfo:always</arg>
+						<arg>--add-exports</arg><arg>java.base/jdk.internal.misc=hosh</arg>
 					</compilerArgs>
 				</configuration>
 			</plugin>

--- a/src/main/antlr4/hosh/antlr4/Hosh.g4
+++ b/src/main/antlr4/hosh/antlr4/Hosh.g4
@@ -4,7 +4,6 @@ program
 	: ( stmt )* EOF
 	;
 
-
 stmt
 	: sequence terminator?
 	;
@@ -23,6 +22,7 @@ pipeline
 command
 	: wrapped
 	| simple
+	| lambda
 	;
 
 wrapped
@@ -31,10 +31,13 @@ wrapped
 	| wrapped '}' // will be rejected by compiler
 	;
 
-
 simple
 	: invocation
 	;
+
+lambda
+    : '{' ID '->' stmt '}'
+    ;
 
 // by now compiler requires command (ID) to be statically defined
 // later should be possible to compile line by line, performing variable expansion before compiling
@@ -98,4 +101,3 @@ COMMENT
 WS
 	: [ \t\n\r]+ -> skip
 	;
-	

--- a/src/main/java/hosh/Hosh.java
+++ b/src/main/java/hosh/Hosh.java
@@ -158,11 +158,11 @@ public class Hosh {
 		injector.setState(state);
 		injector.setTerminal(terminal);
 		bootstrap.registerAllBuiltins(state);
-		CommandResolver commandResolver = CommandResolvers.builtinsThenExternal(state, injector);
+		CommandResolver commandResolver = CommandResolvers.builtinsThenExternal(state);
 		Compiler compiler = new Compiler(commandResolver);
 		OutputChannel out = new CancellableChannel(new ConsoleChannel(terminal, Ansi.Style.NONE));
 		OutputChannel err = new CancellableChannel(new ConsoleChannel(terminal, Ansi.Style.FG_RED));
-		Interpreter interpreter = new Interpreter(state);
+		Interpreter interpreter = new Interpreter(state, injector);
 		CommandLine commandLine;
 		Options options = createOptions();
 		CommandLineParser parser = new DefaultParser();

--- a/src/main/java/hosh/runtime/CommandResolvers.java
+++ b/src/main/java/hosh/runtime/CommandResolvers.java
@@ -45,13 +45,13 @@ public class CommandResolvers {
 	private CommandResolvers() {
 	}
 
-	public static CommandResolver builtinsThenExternal(State state, Injector injector) {
+	public static CommandResolver builtinsThenExternal(State state) {
 		boolean isWindows = System.getProperty("os.name").startsWith("Windows");
 		List<CommandResolver> order = new ArrayList<>();
-		order.add(new BuiltinCommandResolver(state, injector));
-		order.add(new ExternalCommandResolver(state, injector));
+		order.add(new BuiltinCommandResolver(state));
+		order.add(new ExternalCommandResolver(state));
 		if (isWindows) {
-			order.add(new WindowsCommandResolver(state, injector));
+			order.add(new WindowsCommandResolver(state));
 		}
 		return new AggregateCommandResolver(order);
 	}
@@ -82,11 +82,9 @@ public class CommandResolvers {
 
 		private final State state;
 
-		private final Injector injector;
 
-		public ExternalCommandResolver(State state, Injector injector) {
+		public ExternalCommandResolver(State state) {
 			this.state = state;
-			this.injector = injector;
 		}
 
 		@Override
@@ -114,7 +112,6 @@ public class CommandResolvers {
 			if (isExecutable(candidate)) {
 				LOGGER.info(() -> String.format("  found in %s", candidate));
 				ExternalCommand command = new ExternalCommand(candidate);
-				injector.injectDeps(command);
 				return Optional.of(command);
 			} else {
 				return Optional.empty();
@@ -132,11 +129,9 @@ public class CommandResolvers {
 
 		private final State state;
 
-		private final Injector injector;
 
-		public BuiltinCommandResolver(State state, Injector injector) {
+		public BuiltinCommandResolver(State state) {
 			this.state = state;
-			this.injector = injector;
 		}
 
 		@Override
@@ -148,7 +143,6 @@ public class CommandResolvers {
 				return Optional.empty();
 			} else {
 				Command command = commandSupplier.get();
-				injector.injectDeps(command);
 				LOGGER.info(() -> String.format("  found '%s'", command.getClass()));
 				return Optional.of(command);
 			}
@@ -161,9 +155,9 @@ public class CommandResolvers {
 
 		private final ExternalCommandResolver resolver;
 
-		public WindowsCommandResolver(State state, Injector injector) {
+		public WindowsCommandResolver(State state) {
 			this.state = state;
-			resolver = new ExternalCommandResolver(state, injector);
+			resolver = new ExternalCommandResolver(state);
 		}
 
 		@Override

--- a/src/main/java/hosh/runtime/Compiler.java
+++ b/src/main/java/hosh/runtime/Compiler.java
@@ -152,8 +152,8 @@ public class Compiler {
 
 	private Statement compileLambda(HoshParser.LambdaContext lambda) {
 		Statement nestedStatement = compileStatement(lambda.stmt());
-		Key key = Keys.of(lambda.ID().getSymbol().getText());
-		return new Statement(new LambdaCommand(key, nestedStatement), List.of(), "lambda");
+		String key = lambda.ID().getSymbol().getText();
+		return new Statement(new LambdaCommand(nestedStatement, key), List.of(), "lambda");
 	}
 
 	private List<Resolvable> compileArguments(InvocationContext ctx) {

--- a/src/main/java/hosh/runtime/Compiler.java
+++ b/src/main/java/hosh/runtime/Compiler.java
@@ -37,8 +37,6 @@ import hosh.antlr4.HoshParser.WrappedContext;
 import hosh.doc.Todo;
 import hosh.spi.Command;
 import hosh.spi.CommandWrapper;
-import hosh.spi.Key;
-import hosh.spi.Keys;
 import hosh.spi.State;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;

--- a/src/main/java/hosh/runtime/Interpreter.java
+++ b/src/main/java/hosh/runtime/Interpreter.java
@@ -50,9 +50,11 @@ public class Interpreter {
 	private static final Logger LOGGER = LoggerFactory.forEnclosingClass();
 
 	private final State state;
+	private final Injector injector;
 
-	public Interpreter(State state) {
+	public Interpreter(State state, Injector injector) {
 		this.state = state;
+		this.injector = injector;
 	}
 
 	public ExitStatus eval(Program program, OutputChannel out, OutputChannel err) {
@@ -98,6 +100,7 @@ public class Interpreter {
 	protected ExitStatus eval(Statement statement, InputChannel in, OutputChannel out, OutputChannel err) {
 		Command command = statement.getCommand();
 		injectInterpreter(command);
+		injector.injectDeps(command);
 		List<String> resolvedArguments = resolveArguments(statement.getArguments());
 		changeCurrentThreadName(statement.getLocation(), resolvedArguments);
 		return command.run(resolvedArguments, in, out, new WithLocation(err, statement.getLocation()));

--- a/src/main/java/hosh/runtime/LambdaCommand.java
+++ b/src/main/java/hosh/runtime/LambdaCommand.java
@@ -84,4 +84,8 @@ public class LambdaCommand implements Command, InterpreterAware, StateAware {
 		state.getVariables().remove(key);
 		return ExitStatus.success();
 	}
+
+	public String getKey() {
+		return key;
+	}
 }

--- a/src/main/java/hosh/runtime/LambdaCommand.java
+++ b/src/main/java/hosh/runtime/LambdaCommand.java
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018-2020 Davide Angelocola
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package hosh.runtime;
+
+import hosh.spi.Command;
+import hosh.spi.ExitStatus;
+import hosh.spi.InputChannel;
+import hosh.spi.Key;
+import hosh.spi.OutputChannel;
+import hosh.spi.Record;
+import hosh.spi.Value;
+
+import java.util.List;
+
+public class LambdaCommand implements Command, InterpreterAware {
+
+	private final Key key;
+	private final Compiler.Statement statement;
+	private Interpreter interpreter;
+
+	public LambdaCommand(Key key, Compiler.Statement statement) {
+		this.key = key;
+		this.statement = statement;
+	}
+
+	@Override
+	public void setInterpreter(Interpreter interpreter) {
+		this.interpreter = interpreter;
+	}
+
+	@Override
+	public ExitStatus run(List<String> args, InputChannel in, OutputChannel out, OutputChannel err) {
+		for (Record record : InputChannel.iterate(in)) {
+			Value value = record.value(key).orElseThrow(IllegalArgumentException::new);
+			ExitStatus eval = interpreter.eval(statement, in, out, err);
+			if (eval.isError()) {
+				return eval;
+			}
+		}
+		return ExitStatus.success();
+	}
+}

--- a/src/main/java/hosh/runtime/LambdaCommand.java
+++ b/src/main/java/hosh/runtime/LambdaCommand.java
@@ -78,7 +78,6 @@ public class LambdaCommand implements Command, InterpreterAware, StateAware {
 				}
 			} finally {
 				// any change made by inner statement to variable will be lost here
-				// create a new Resolvable implementation?
 				state.setVariables(original);
 			}
 		}

--- a/src/main/java/hosh/runtime/LambdaCommand.java
+++ b/src/main/java/hosh/runtime/LambdaCommand.java
@@ -23,6 +23,7 @@
  */
 package hosh.runtime;
 
+import hosh.doc.Todo;
 import hosh.spi.Command;
 import hosh.spi.ExitStatus;
 import hosh.spi.InputChannel;
@@ -58,6 +59,15 @@ public class LambdaCommand implements Command, InterpreterAware, StateAware {
 		this.state = state;
 	}
 
+	@Todo(description = "make a copy of variables to avoid concurrent modification in commands using state.getVariables")
+	// env | { name -> echo ${name} }
+	// Caused by: java.util.ConcurrentModificationException
+	//        at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:719)
+	//        at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:751)
+	//        at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:749)
+	//        at hosh.modules.SystemModule$Env.run(SystemModule.java:135)
+	//        at hosh.runtime.Interpreter.eval(Interpreter.java:106)
+	//        at hosh.runtime.PipelineCommand.lambda$runAsync$2(PipelineCommand.java:1
 	@Override
 	public ExitStatus run(List<String> args, InputChannel in, OutputChannel out, OutputChannel err) {
 		for (Record record : InputChannel.iterate(in)) {

--- a/src/main/java/hosh/runtime/LambdaCommand.java
+++ b/src/main/java/hosh/runtime/LambdaCommand.java
@@ -69,6 +69,7 @@ public class LambdaCommand implements Command, InterpreterAware, StateAware {
 				return eval;
 			}
 		}
+		state.getVariables().remove(key.name());
 		return ExitStatus.success();
 	}
 }

--- a/src/main/java/hosh/spi/State.java
+++ b/src/main/java/hosh/spi/State.java
@@ -42,7 +42,7 @@ import java.util.function.Supplier;
 public class State {
 
 	// variables
-	private final Map<String, String> variables = new LinkedHashMap<>();
+	private Map<String, String> variables = new LinkedHashMap<>();
 
 	// registered commands
 	private final Map<String, Supplier<Command>> commands = new LinkedHashMap<>();
@@ -66,6 +66,10 @@ public class State {
 
 	public Map<String, Supplier<Command>> getCommands() {
 		return commands;
+	}
+
+	public void setVariables(Map<String, String> variables) {
+		this.variables = variables;
 	}
 
 	public Map<String, String> getVariables() {

--- a/src/main/java/hosh/spi/Values.java
+++ b/src/main/java/hosh/spi/Values.java
@@ -437,6 +437,9 @@ public class Values {
 			if (type.equals(Path.class)) {
 				return Optional.of(type.cast(path));
 			}
+			if (type.equals(String.class)) {
+				return Optional.of(type.cast(path.toString()));
+			}
 			return Optional.empty();
 		}
 

--- a/src/main/java/hosh/spi/Values.java
+++ b/src/main/java/hosh/spi/Values.java
@@ -268,6 +268,15 @@ public class Values {
 				throw new IllegalArgumentException("cannot compare " + this + " to " + obj);
 			}
 		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> Optional<T> unwrap(Class<T> type) {
+			if (type == String.class) {
+				return (Optional<T>) Optional.of(Long.toString(number));
+			}
+			return Optional.empty();
+		}
 	}
 
 	static final class None implements Value {

--- a/src/test/java/hosh/fitness/DocFitnessTest.java
+++ b/src/test/java/hosh/fitness/DocFitnessTest.java
@@ -80,7 +80,7 @@ public class DocFitnessTest {
 			BootstrapBuiltins bootstrapBuiltins = new BootstrapBuiltins();
 			bootstrapBuiltins.registerAllBuiltins(state);
 			assertThat(state.getCommands()).isNotEmpty();
-			compiler = new Compiler(new CommandResolvers.BuiltinCommandResolver(state, new Injector()));
+			compiler = new Compiler(new CommandResolvers.BuiltinCommandResolver(state));
 		}
 
 		@Override

--- a/src/test/java/hosh/integration/HoshIT.java
+++ b/src/test/java/hosh/integration/HoshIT.java
@@ -475,6 +475,20 @@ public class HoshIT {
 	}
 
 	@Test
+	public void lambdaAfterGlobExpansion() throws Exception {
+		Path path = givenFolder("A.class", "B.class", "C.java");
+		Path scriptPath = givenScript("walk " + path.toAbsolutePath() + " | glob '*.class' | { path -> rm ${path} }");
+		Process hosh = givenHoshProcess(scriptPath.toString());
+		String output = consumeOutput(hosh);
+		int exitCode = hosh.waitFor();
+		assertThat(exitCode).isEqualTo(0);
+		assertThat(output).isEmpty();
+		assertThat(path.resolve("A.class")).doesNotExist();
+		assertThat(path.resolve("B.class")).doesNotExist();
+		assertThat(path.resolve("C.java")).exists();
+	}
+
+	@Test
 	public void versionLongOption() throws Exception {
 		Process hosh = givenHoshProcess("--version");
 		String output = consumeOutput(hosh);
@@ -533,6 +547,14 @@ public class HoshIT {
 		Path scriptPath = temporaryFolder.newFile("test.hosh").toPath();
 		Files.write(scriptPath, List.of(lines));
 		return scriptPath;
+	}
+
+	private Path givenFolder(String... filenames) throws IOException {
+		Path folder = temporaryFolder.newFolder("folder").toPath();
+		for (String filename : filenames) {
+			Files.write(folder.resolve(filename), List.of("some content"));
+		}
+		return folder;
 	}
 
 	private Process givenHoshProcess(String... args) throws IOException {

--- a/src/test/java/hosh/modules/TextModuleTest.java
+++ b/src/test/java/hosh/modules/TextModuleTest.java
@@ -134,7 +134,7 @@ public class TextModuleTest {
 		@SuppressWarnings("unchecked")
 		@Test
 		public void trimKeyOfDifferentType() {
-			Record record = Records.singleton(Keys.COUNT, Values.ofNumeric(42));
+			Record record = Records.singleton(Keys.COUNT, Values.ofInstant(Instant.EPOCH));
 			given(in.recv()).willReturn(Optional.of(record), Optional.empty());
 			ExitStatus exitStatus = sut.run(List.of(Keys.COUNT.name()), in, out, err);
 			assertThat(exitStatus).isSuccess();

--- a/src/test/java/hosh/runtime/CommandResolversTest.java
+++ b/src/test/java/hosh/runtime/CommandResolversTest.java
@@ -66,14 +66,11 @@ public class CommandResolversTest {
 		@Mock(stubOnly = true)
 		private State state;
 
-		@Mock
-		private Injector injector;
-
 		private CommandResolver sut;
 
 		@BeforeEach
 		public void setup() {
-			sut = CommandResolvers.builtinsThenExternal(state, injector);
+			sut = CommandResolvers.builtinsThenExternal(state);
 		}
 
 		@Test
@@ -90,7 +87,6 @@ public class CommandResolversTest {
 			given(state.getCommands()).willReturn(Map.of("test", () -> command));
 			Optional<Command> result = sut.tryResolve("test");
 			assertThat(result).isPresent().hasValue(command);
-			then(injector).should().injectDeps(command);
 		}
 
 		@Test
@@ -139,7 +135,6 @@ public class CommandResolversTest {
 			given(state.getCwd()).willReturn(Paths.get("."));
 			Optional<Command> result = sut.tryResolve("test");
 			assertThat(result).isPresent();
-			then(injector).should().injectDeps(any());
 		}
 		@Test
 		@EnabledOnOs(OS.WINDOWS)
@@ -163,7 +158,6 @@ public class CommandResolversTest {
 			given(state.getVariables()).willReturn(Map.of("PATHEXT", ".COM;.EXE;.BAT;.CMD"));
 			Optional<Command> result = sut.tryResolve("test");
 			assertThat(result).isPresent();
-			then(injector).should().injectDeps(any());
 		}
 
 		@Test
@@ -174,7 +168,6 @@ public class CommandResolversTest {
 			given(state.getCwd()).willReturn(Paths.get("."));
 			Optional<Command> result = sut.tryResolve("./test");
 			assertThat(result).isPresent();
-			then(injector).should().injectDeps(any());
 		}
 
 		@Test
@@ -197,14 +190,11 @@ public class CommandResolversTest {
 		@Mock(stubOnly = true)
 		private State state;
 
-		@Mock(stubOnly = true)
-		private Injector injector;
-
 		private WindowsCommandResolver sut;
 
 		@BeforeEach
 		public void setup() {
-			sut = new WindowsCommandResolver(state, injector);
+			sut = new WindowsCommandResolver(state);
 		}
 
 		@Test

--- a/src/test/java/hosh/runtime/CompilerTest.java
+++ b/src/test/java/hosh/runtime/CompilerTest.java
@@ -29,6 +29,7 @@ import hosh.runtime.Compiler.Program;
 import hosh.runtime.Compiler.Statement;
 import hosh.spi.Command;
 import hosh.spi.CommandWrapper;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -399,7 +400,7 @@ public class CompilerTest {
 			.hasSize(1)
 			.first().satisfies(statement -> {
 			assertThat(statement.getArguments()).isEmpty();
-			assertThat(statement.getCommand()).isInstanceOf(PipelineCommand.class);
+			assertThat(statement.getCommand()).asInstanceOf(InstanceOfAssertFactories.type(PipelineCommand.class));
 		});
 	}
 }

--- a/src/test/java/hosh/runtime/CompilerTest.java
+++ b/src/test/java/hosh/runtime/CompilerTest.java
@@ -399,7 +399,7 @@ public class CompilerTest {
 			.hasSize(1)
 			.first().satisfies(statement -> {
 			assertThat(statement.getArguments()).isEmpty();
-			assertThat(statement.getCommand()).isInstanceOf(SequenceCommand.class);
+			assertThat(statement.getCommand()).isInstanceOf(PipelineCommand.class);
 		});
 	}
 }

--- a/src/test/java/hosh/runtime/CompilerTest.java
+++ b/src/test/java/hosh/runtime/CompilerTest.java
@@ -389,4 +389,17 @@ public class CompilerTest {
 			assertThat(statement.getCommand()).isInstanceOf(SequenceCommand.class);
 		});
 	}
+
+	@Test
+	public void lambda() {
+		doReturn(Optional.of(command)).when(commandResolver).tryResolve("ls");
+		doReturn(Optional.of(anotherCommand)).when(commandResolver).tryResolve("echo");
+		Program program = sut.compile("ls | { path -> echo ${path} }");
+		assertThat(program.getStatements())
+			.hasSize(1)
+			.first().satisfies(statement -> {
+			assertThat(statement.getArguments()).isEmpty();
+			assertThat(statement.getCommand()).isInstanceOf(SequenceCommand.class);
+		});
+	}
 }

--- a/src/test/java/hosh/runtime/CompilerTest.java
+++ b/src/test/java/hosh/runtime/CompilerTest.java
@@ -398,9 +398,18 @@ public class CompilerTest {
 		Program program = sut.compile("ls | { path -> echo ${path} }");
 		assertThat(program.getStatements())
 			.hasSize(1)
-			.first().satisfies(statement -> {
-			assertThat(statement.getArguments()).isEmpty();
-			assertThat(statement.getCommand()).asInstanceOf(InstanceOfAssertFactories.type(PipelineCommand.class));
-		});
+			.first()
+			.satisfies(statement -> {
+				assertThat(statement.getArguments()).isEmpty();
+				assertThat(statement.getCommand())
+					.asInstanceOf(InstanceOfAssertFactories.type(PipelineCommand.class))
+					.satisfies(pipelineCommand -> {
+						assertThat(pipelineCommand.getConsumer().getCommand())
+							.asInstanceOf(InstanceOfAssertFactories.type(LambdaCommand.class))
+							.satisfies(lambdaCommand -> {
+								assertThat(lambdaCommand.getKey()).isEqualTo("path");
+							});
+					});
+			});
 	}
 }

--- a/src/test/java/hosh/runtime/InterpreterTest.java
+++ b/src/test/java/hosh/runtime/InterpreterTest.java
@@ -64,6 +64,9 @@ public class InterpreterTest {
 	private State state;
 
 	@Mock
+	private Injector injector;
+
+	@Mock
 	private InputChannel in;
 
 	@Mock
@@ -89,7 +92,7 @@ public class InterpreterTest {
 
 	@BeforeEach
 	public void setup() {
-		sut = new Interpreter(state);
+		sut = new Interpreter(state, injector);
 	}
 
 	@Test

--- a/src/test/java/hosh/runtime/LambdaCommandTest.java
+++ b/src/test/java/hosh/runtime/LambdaCommandTest.java
@@ -1,0 +1,85 @@
+package hosh.runtime;
+
+import hosh.spi.ExitStatus;
+import hosh.spi.InputChannel;
+import hosh.spi.Keys;
+import hosh.spi.OutputChannel;
+import hosh.spi.Records;
+import hosh.spi.State;
+import hosh.spi.Values;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static hosh.testsupport.ExitStatusAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+public class LambdaCommandTest {
+
+	@Mock
+	private Interpreter interpreter;
+
+	@Mock(stubOnly = true)
+	private Compiler.Statement statement;
+
+	@Mock(stubOnly = true)
+	private InputChannel in;
+
+	@Mock(stubOnly = true)
+	private OutputChannel out;
+
+	@Mock(stubOnly = true)
+	private OutputChannel err;
+
+	@Mock
+	private State state;
+
+	private LambdaCommand sut;
+
+	@BeforeEach
+	public void setUp() {
+		sut = new LambdaCommand(statement, Keys.PATH.name());
+		sut.setState(state);
+		sut.setInterpreter(interpreter);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void success() {
+		Map<String, String> variables = new HashMap<>();
+		given(state.getVariables()).willReturn(variables);
+		given(interpreter.eval(statement, in, out, err)).willReturn(ExitStatus.success());
+		given(in.recv()).willReturn(Optional.of(Records.singleton(Keys.PATH, Values.ofPath(Path.of("file")))), Optional.empty());
+		ExitStatus exitStatus = sut.run(List.of(), in, out, err);
+		assertThat(exitStatus).isSuccess();
+		assertThat(variables).isEmpty();
+		then(state).should().setVariables(Collections.singletonMap("path", "file"));
+		then(state).should().setVariables(variables);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void error() {
+		Map<String, String> variables = new HashMap<>();
+		given(state.getVariables()).willReturn(variables);
+		given(interpreter.eval(statement, in, out, err)).willReturn(ExitStatus.error());
+		given(in.recv()).willReturn(Optional.of(Records.singleton(Keys.PATH, Values.ofPath(Path.of("file")))), Optional.empty());
+		ExitStatus exitStatus = sut.run(List.of(), in, out, err);
+		assertThat(exitStatus).isError();
+		assertThat(variables).isEmpty();
+		then(state).should().setVariables(variables);
+	}
+
+}


### PR DESCRIPTION
tentative fix for #89 

Limitations of lambda command:
- only 1 argument is permitted by now (easy to fix)
- hacking `state.getVariables()`, clean solution would be to create a new `Resolvable` 
- [x] `Value.unwrap(String.class)` for several types
- [x] missing unit test for `LambdaCommand`
